### PR TITLE
[SPRINT10] ITER24: Add source code for the iter24

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 
 import (
 	"context"
+	"crypto/rsa"
 	"fmt"
 	"os"
 	"os/signal"
@@ -38,9 +39,15 @@ func NewAgent() (*Agent, error) {
 		return nil, fmt.Errorf("logger.NewZapLogger: %w", err)
 	}
 
-	publicKey, err := cryptutils.LoadRSAPublicKey(cfg.CryptoKey)
-	if err != nil {
-		return nil, fmt.Errorf("cryptutils.LoadRSAPublicKey: %w", err)
+	var publicKey *rsa.PublicKey
+
+	if cfg.CryptoKey != "" {
+		log.Info("Loading crypto key " + cfg.CryptoKey)
+
+		publicKey, err = cryptutils.LoadRSAPublicKey(cfg.CryptoKey)
+		if err != nil {
+			return nil, fmt.Errorf("cryptutils.LoadRSAPublicKey: %w", err)
+		}
 	}
 
 	mon := monitor.NewMonitor(

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -71,8 +71,6 @@ func readConfigFile(file string, cfg *config) error {
 
 	if cfg.CryptoKey == "" {
 		if fileCfg.CryptoKey == "" {
-			cfg.CryptoKey = "./tls/public.key"
-		} else {
 			cfg.CryptoKey = fileCfg.CryptoKey
 		}
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -19,6 +19,7 @@ type config struct {
 	DatabaseDSN   string `env:"DATABASE_DSN" json:"database_dsn"`
 	SignKey       string `env:"KEY" json:"sign_key"`
 	CryptoKey     string `env:"CRYPTO_KEY" json:"crypto_key"`
+	TrustedSubnet string `env:"TRUSTED_SUBNET" json:"trusted_subnet"`
 	StoreFile     string `env:"FILE_STORAGE_PATH" json:"store_file"`
 	StoreInterval int    `env:"STORE_INTERVAL" json:"store_interval"`
 	RestoreOnBoot bool   `env:"RESTORE" json:"restore"`
@@ -41,6 +42,7 @@ func newConfig() (config, error) {
 	flag.StringVar(&cfg.DatabaseDSN, "d", "", "database connection string [env:DATABASE_DSN]")
 	flag.StringVar(&cfg.SignKey, "k", "", "signing key [env:KEY]")
 	flag.StringVar(&cfg.CryptoKey, "crypto-key", "", "path to RSA private key file to decrypt messages from Agent [env:CRYPTO_KEY]")
+	flag.StringVar(&cfg.TrustedSubnet, "t", "", "trusted subnet [env:TRUSTED_SUBNET]")
 	flag.StringVar(&cfg.StoreFile, "f", "", "filepath to store metrics data to [env:FILE_STORAGE_PATH]")
 	flag.IntVar(&cfg.StoreInterval, "i", 0, "interval in seconds to store metrics data into file [env:STORE_INTERVAL]")
 	flag.BoolVar(&cfg.RestoreOnBoot, "r", false, "whether or not to restore metrics data from file [env:RESTORE]")
@@ -73,8 +75,6 @@ func readConfigFile(file string, cfg *config) error {
 
 	if cfg.CryptoKey == "" {
 		if fileCfg.CryptoKey == "" {
-			cfg.CryptoKey = "./tls/private.key"
-		} else {
 			cfg.CryptoKey = fileCfg.CryptoKey
 		}
 	}
@@ -101,6 +101,10 @@ func readConfigFile(file string, cfg *config) error {
 
 	if cfg.SignKey == "" {
 		cfg.SignKey = fileCfg.SignKey
+	}
+
+	if cfg.TrustedSubnet == "" {
+		cfg.TrustedSubnet = fileCfg.TrustedSubnet
 	}
 
 	if cfg.StoreFile == "" {

--- a/internal/server/httpserver/router/middlewares/cryptography.go
+++ b/internal/server/httpserver/router/middlewares/cryptography.go
@@ -13,6 +13,13 @@ import (
 	"github.com/andymarkow/go-metrics-collector/internal/cryptutils"
 )
 
+// Cryptography is a router middleware that decrypts the request body using RSA-OAEP decryption.
+//
+// The middleware expects the request body to be encrypted using the public key of the server.
+// The middleware decrypts the body using the private key of the server and updates the request body
+// with the decrypted data.
+//
+// If the decryption fails, the middleware returns a 500 status code.
 func (m *Middlewares) Cryptography(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)

--- a/internal/server/httpserver/router/middlewares/logger.go
+++ b/internal/server/httpserver/router/middlewares/logger.go
@@ -46,8 +46,21 @@ func (m *Middlewares) Logger(next http.Handler) http.Handler {
 			responseData:   responseData,
 		}
 
+		remoteAddr, err := getRemoteIPAddr(r)
+		if err != nil {
+			m.log.Error("failed to get remote address", zap.Error(err))
+		}
+
+		scheme := "http"
+
+		if r.TLS != nil {
+			scheme = "https"
+		}
+
 		defer func() {
 			m.log.Info("request",
+				zap.String("remote_addr", remoteAddr.String()),
+				zap.String("host", scheme+"://"+r.Host),
 				zap.String("uri", r.RequestURI),
 				zap.String("method", r.Method),
 				zap.Int("status", responseData.status),

--- a/internal/server/httpserver/router/middlewares/middlewares.go
+++ b/internal/server/httpserver/router/middlewares/middlewares.go
@@ -3,6 +3,7 @@ package middlewares
 
 import (
 	"crypto/rsa"
+	"net"
 
 	"go.uber.org/zap"
 )
@@ -11,6 +12,7 @@ import (
 type Middlewares struct {
 	log           *zap.Logger
 	cryptoPrivKey *rsa.PrivateKey
+	trustedSubnet *net.IPNet
 	signKey       []byte
 }
 
@@ -46,8 +48,16 @@ func WithSignKey(signKey []byte) Option {
 	}
 }
 
+// WithCryptoPrivateKey is a router middleware option that sets decryption RSA private key.
 func WithCryptoPrivateKey(key *rsa.PrivateKey) Option {
 	return func(m *Middlewares) {
 		m.cryptoPrivKey = key
+	}
+}
+
+// WithTrustedSubnet is a router middleware option that sets trusted subnet as a whitelist.
+func WithTrustedSubnet(subnet *net.IPNet) Option {
+	return func(m *Middlewares) {
+		m.trustedSubnet = subnet
 	}
 }

--- a/internal/server/httpserver/router/middlewares/signature.go
+++ b/internal/server/httpserver/router/middlewares/signature.go
@@ -29,6 +29,14 @@ func (m *Middlewares) HashSumValidator(next http.Handler) http.Handler {
 
 			return
 		}
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				m.log.Error("failed to close request body", zap.Error(err))
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+		}()
 
 		r.Body = io.NopCloser(bytes.NewBuffer(body))
 

--- a/internal/server/httpserver/router/middlewares/whitelist.go
+++ b/internal/server/httpserver/router/middlewares/whitelist.go
@@ -1,0 +1,69 @@
+package middlewares
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Whitelist returns a middleware that allows requests only from IPs in the trusted
+// subnet. If the trusted subnet is not set, all IPs are allowed. The middleware
+// checks the X-Real-IP and X-Forwarded-For headers in order, and if neither is set,
+// it uses the remote address. If the IP is not in the trusted subnet, it returns a
+// 403.
+func (m *Middlewares) Whitelist(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If the trusted subnet is not set, allow all IPs.
+		if m.trustedSubnet == nil {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		ip, err := getRemoteIPAddr(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		// If the IP is not in the trusted subnet, return a 403.
+		if !m.trustedSubnet.Contains(ip) {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// getRemoteIPAddr returns the remote IP address of the request. It first tries to
+// parse the X-Real-IP header, then the X-Forwarded-For header, and finally the
+// remote address. If any of these fail, it returns an error.
+func getRemoteIPAddr(req *http.Request) (net.IP, error) {
+	// Try the X-Real-IP header.
+	ip := net.ParseIP(req.Header.Get("X-Real-IP"))
+	if ip == nil {
+		// If the X-Real-IP header is not set, try the X-Forwarded-For header.
+		ips := strings.Split(req.Header.Get("X-Forwarded-For"), ",")
+
+		if len(ips) > 0 {
+			// Try to parse the first IP in the list.
+			ip = net.ParseIP(ips[0])
+		}
+	}
+
+	// If the IP is still not set, use the remote address.
+	if ip == nil {
+		ipStr, _, err := net.SplitHostPort(req.RemoteAddr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse remote address: %w", err)
+		}
+
+		ip = net.ParseIP(ipStr)
+	}
+
+	return ip, nil
+}

--- a/internal/server/httpserver/router/router.go
+++ b/internal/server/httpserver/router/router.go
@@ -3,6 +3,7 @@ package router
 
 import (
 	"crypto/rsa"
+	"net"
 	_ "net/http/pprof" //nolint:gosec // Enable pprof debugger
 
 	"github.com/go-chi/chi/v5"
@@ -16,18 +17,19 @@ import (
 
 type routerOpts struct {
 	logger        *zap.Logger
+	trustedSubnet *net.IPNet
 	cryptoPrivKey *rsa.PrivateKey
 	signKey       []byte
 }
 
 func NewRouter(store storage.Storage, opts ...Option) *chi.Mux {
-	rOpts := routerOpts{
+	rOpts := &routerOpts{
 		logger:  zap.NewNop(),
 		signKey: make([]byte, 0),
 	}
 
 	for _, opt := range opts {
-		opt(&rOpts)
+		opt(rOpts)
 	}
 
 	h := handlers.NewHandlers(store, handlers.WithLogger(rOpts.logger))
@@ -38,12 +40,14 @@ func NewRouter(store storage.Storage, opts ...Option) *chi.Mux {
 		middlewares.WithLogger(rOpts.logger),
 		middlewares.WithSignKey(rOpts.signKey),
 		middlewares.WithCryptoPrivateKey(rOpts.cryptoPrivKey),
+		middlewares.WithTrustedSubnet(rOpts.trustedSubnet),
 	)
 
 	r.Use(
 		middleware.Recoverer,
 		middleware.StripSlashes,
 		mw.Logger,
+		mw.Whitelist,
 	)
 
 	var useHashSumValidator bool
@@ -74,7 +78,10 @@ func NewRouter(store storage.Storage, opts ...Option) *chi.Mux {
 
 	r.Group(func(r chi.Router) {
 		r.Use(mw.Compress)
-		r.Use(mw.Cryptography)
+
+		if rOpts.cryptoPrivKey != nil {
+			r.Use(mw.Cryptography)
+		}
 
 		if useHashSumValidator {
 			r.Use(mw.HashSumValidator)
@@ -107,5 +114,12 @@ func WithSignKey(signKey []byte) Option {
 func WithCryptoPrivateKey(key *rsa.PrivateKey) Option {
 	return func(o *routerOpts) {
 		o.cryptoPrivKey = key
+	}
+}
+
+// WithTrustedSubnet is a router option that sets trusted subnet.
+func WithTrustedSubnet(subnet *net.IPNet) Option {
+	return func(o *routerOpts) {
+		o.trustedSubnet = subnet
 	}
 }

--- a/internal/server/httpserver/router/router.go
+++ b/internal/server/httpserver/router/router.go
@@ -77,11 +77,11 @@ func NewRouter(store storage.Storage, opts ...Option) *chi.Mux {
 	})
 
 	r.Group(func(r chi.Router) {
-		r.Use(mw.Compress)
-
 		if rOpts.cryptoPrivKey != nil {
 			r.Use(mw.Cryptography)
 		}
+
+		r.Use(mw.Compress)
 
 		if useHashSumValidator {
 			r.Use(mw.HashSumValidator)


### PR DESCRIPTION
Добавьте в конфигурационный JSON-файл сервера поле trusted_subnet (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).
Добавьте в запрос агента заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.
При отправке метрик агентом серверу нужно проверять, что переданный в заголовке запроса X-Real-IP IP-адрес агента входит в доверенную подсеть, в противном случае возвращать статус ответа 403 Forbidden.
При пустом значении переменной trusted_subnet метрики должны обрабатываться сервером без дополнительных ограничений.